### PR TITLE
practice / #1 / 웹팩이전의 세계와 모듈의 개념 강의 공부

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # webpackPractice
+
+생활코딩의 Webpack 강의를 듣고 공부한 내용입니다.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <!-- 1. 스크립트 파일 명시하기 -->
+    <script src="./source/hello.js"></script>
+    <script src="./source/world.js"></script>
+    <!-- "...프로그래밍의 작업이 어느정도 규모를 넘기 시작하면 변수의 충돌은 중요한 이슈이다. 따라서 '모듈화'에 대한 개념이 필요하다. <head>태그 안에서 script파일을 명시(?)하는 방법은 수직적이다. 간단하고 편리하다. 하지만 동일한 이름의 변수가 함수가 있다면 할당된 값들이 덮어씌워지거나 충돌할 수 있다." -->
+  </head>
+  <body>
+    <h1>hello, webpack</h1>
+    <div id="root"></div>
+    <!-- <script>
+      1. 스크립트 파일 명시하기
+      document.querySelector('#root').innerHTML = word;
+      - head태그 안에 script파일을 가져온 뒤 (10,11번줄 제외하고)12번줄을 작성하면  word라고만 나옴
+      - 가장 마지막에 읽은 world.js의 변수 word로 재할당 되어서 값이 변경되어 버림
+      - 만약 수백개의 js파일을 로드해서 사용하게 된다면 변수의 이름이 중복될 가능성이 있음
+    </script> -->
+    <script type="module">
+      // 2. 명시한 스크립트 파일에서 모듈 가져와 사용하기
+      import hello_word from './source/hello.js';
+      import world_word from './source/world.js';
+      document.querySelector('#root').innerHTML = hello_word + ' ' + world_word;
+      // "... <script>태그의 type을 module로 만들어주고 외부에 있는 js파일 중 특정 변수나 함수만을 import하도록 코딩하면 효율적일 것 같다. 왜냐하면 외부 js파일에서 쓰이지 않을 변수나 함수를 굳이 읽어올 필요가 없기 때문이다. 또한 복잡한 애플리케이션의 변수충돌을 개발자가 컨트롤 가능한 수준으로 끌어내릴 수 있다. " + 하지만 오래된 브라우저에서는 export, import가 동작하지 않고 만약 수백개의 js, css, 이미지 파일이 있다고 하면 네트워크 연결이 증가해 네트워크 부하가 커져 속도가 느려짐
+      // 이제는 콘솔창에 word를 쳐도 검색이 되지 않음 (word is not defined)
+      // word라는 값은 명시적으로 export하기 전까지는 hello.js안에서만 유효한 값이 되버림 (디렉토리 안에서만 파일 이름이 유효한 것 처럼)
+    </script>
+  </body>
+</html>

--- a/source/hello.js
+++ b/source/hello.js
@@ -1,0 +1,3 @@
+var word = 'hello';
+
+export default word; // 모듈로 만들어 export하면서 word변수를 index.html에 import해와 사용 할 수 있게 됨

--- a/source/world.js
+++ b/source/world.js
@@ -1,0 +1,3 @@
+var word = 'world';
+
+export default word; // 모듈로 만들어 export하면서 word변수를 index.html에 import해와 사용 할 수 있게 됨


### PR DESCRIPTION
- 웹팩 이전에는 스크립트 파일을 명시해 사용하거나, 명시한 스크립트 파일에서 모듈을 만들어 사용했었음

### 1. 스크립트 파일 명시
```
<html>
  <head>
    <script src="./source/hello.js"></script>
    <script src="./source/world.js"></script>
  </head>
  <body>
    <h1>hello, webpack</h1>
    <div id="root"></div>
    <script>
      document.querySelector('#root').innerHTML = word;
    </script>
  </body>
</html>
```
- hello.js와 world.js 두군데에 같은 이름의 변수 word가 존재하는데도 불구하고 word라고만 나옴
  - 가장 마지막에 읽은 world.js의 변수 word로 재할당 되어서 값이 변경되어 버림
  - 만약 수백개의 js파일을 로드해서 사용하게 된다면 변수의 이름이 중복되어 잘못된 값을 사용하는 에러가 발생할 수 있음

### 2. js파일에서 모듈 export/import해서 사용하기
```
<html>
  <head>
    <script src="./source/hello.js"></script>
    <script src="./source/world.js"></script>
  </head>
  <body>
    <h1>hello, webpack</h1>
    <div id="root"></div>
    <script type="module">
      import hello_word from './source/hello.js';
      import world_word from './source/world.js';
      document.querySelector('#root').innerHTML = hello_word + ' ' + world_word;
    </script>
  </body>
</html>
```
- 외부 js파일에서 쓰이지 않을 변수나 함수를 굳이 읽어올 필요가 없어졌고, 복잡한 애플리케이션의 변수충돌을 개발자가 컨트롤 가능한 수준으로 끌어내릴 수 있음
- 하지만 오래된 브라우저에서는 export, import가 동작하지 않고 만약 수백개의 js, css, 이미지 파일이 있다고 하면 네트워크 연결이 증가해 네트워크 부하가 커져 속도가 느려짐
- 이제는 콘솔창에 word를 쳐도 검색이 되지 않음 (word is not defined)
  - word라는 값은 명시적으로 export하기 전까지는 hello.js안에서만 유효한 값이 되버림 (디렉토리 안에서만 파일 이름이 유효한 것 처럼)